### PR TITLE
Add user api call to create account logic

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -64,6 +64,7 @@ dependencies {
     runtimeOnly("com.h2database:h2")
     annotationProcessor("org.projectlombok:lombok")
     testImplementation("org.springframework.boot:spring-boot-starter-test")
+    testImplementation("com.github.tomakehurst:wiremock-jre8:2.34.0")
 }
 
 dependencyManagement {

--- a/src/main/java/com/guide/common/error/ErrorCode.java
+++ b/src/main/java/com/guide/common/error/ErrorCode.java
@@ -9,12 +9,17 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 @JsonFormat(shape = Shape.OBJECT)
 public enum ErrorCode {
+    // Common
     BAD_REQUEST(4001L, "Invalid Input Value"),
     METHOD_NOT_ALLOWED(4002L, "Request Method Not Supported"),
     NOT_HANDLER_FOUND(4003L, "Non-Existent Api Request"),
     UNKNOWN(9999L, "Unknown Error"),
 
+    // Feign
     RETRY_MAX_ATTEMPTS(5001L, "Max Retry Fail"),
+
+    // User
+    USER_NOT_FOUND(4100L, "User not found during call user-api"),
     USER_CLIENT_UNPROCESSABLE(5002L, "Something wrong during call user-api");
 
     private final long code;

--- a/src/main/java/com/guide/domain/account/api/AccountController.java
+++ b/src/main/java/com/guide/domain/account/api/AccountController.java
@@ -10,20 +10,22 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-@RestController
-@RequestMapping("/api/account")
-@RequiredArgsConstructor
 @Tag(name = "Account", description = "Rest API for Account")
 @ApiResponses(
         value = {
             @ApiResponse(responseCode = "400", description = "Account not found"),
             @ApiResponse(responseCode = "500", description = "Internal server error")
         })
+@Slf4j
+@RequiredArgsConstructor
+@RequestMapping("/api/account")
+@RestController
 public class AccountController {
 
     private final AccountCreateService accountCreateService;
@@ -32,7 +34,10 @@ public class AccountController {
     @ApiResponse(responseCode = "200", description = "OK")
     @PostMapping
     public AccountResponse create(@RequestBody @Valid AccountCreateRequest createRequest) {
+        log.info("Requested for create Account, AccountCreateRequest : {}", createRequest);
         Account account = accountCreateService.create(createRequest);
-        return AccountResponse.of(account);
+        AccountResponse accountResponse = AccountResponse.of(account);
+        log.info("Returned created Account, AccountResponse : {}", accountResponse);
+        return accountResponse;
     }
 }

--- a/src/main/java/com/guide/domain/account/application/AccountCreateService.java
+++ b/src/main/java/com/guide/domain/account/application/AccountCreateService.java
@@ -3,19 +3,29 @@ package com.guide.domain.account.application;
 import com.guide.domain.account.dao.AccountRepository;
 import com.guide.domain.account.dto.AccountCreateRequest;
 import com.guide.domain.account.entity.Account;
+import com.guide.domain.model.User;
+import com.guide.infra.client.UserClient;
+import com.guide.infra.client.dto.UserFindApiResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-@Service
 @RequiredArgsConstructor
 @Transactional
+@Service
 public class AccountCreateService {
 
+    private final UserClient userClient;
     private final AccountRepository accountRepository;
 
     public Account create(final AccountCreateRequest createRequest) {
-        Account account = createRequest.toEntity();
+        UserFindApiResponse userFindApiResponse = userClient.requestUserById(createRequest.userId());
+        User user =
+                User.builder()
+                        .id(userFindApiResponse.data().id())
+                        .email(userFindApiResponse.data().email())
+                        .build();
+        Account account = Account.of(createRequest.name(), user);
         return accountRepository.save(account);
     }
 }

--- a/src/main/java/com/guide/domain/account/application/AccountCreateService.java
+++ b/src/main/java/com/guide/domain/account/application/AccountCreateService.java
@@ -11,13 +11,14 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @RequiredArgsConstructor
-@Transactional
+@Transactional(readOnly = true)
 @Service
 public class AccountCreateService {
 
     private final UserClient userClient;
     private final AccountRepository accountRepository;
 
+    @Transactional
     public Account create(final AccountCreateRequest createRequest) {
         UserFindApiResponse userFindApiResponse = userClient.requestUserById(createRequest.userId());
         User user =

--- a/src/main/java/com/guide/domain/account/dto/AccountCreateRequest.java
+++ b/src/main/java/com/guide/domain/account/dto/AccountCreateRequest.java
@@ -1,15 +1,6 @@
 package com.guide.domain.account.dto;
 
-import com.guide.domain.account.entity.Account;
-import com.guide.domain.model.User;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 
-public record AccountCreateRequest(
-        @NotNull Long userId, @NotBlank String email, @NotBlank String name) {
-
-    public Account toEntity() {
-        User user = User.builder().id(userId).email(email).build();
-        return Account.of(name, user);
-    }
-}
+public record AccountCreateRequest(@NotNull Long userId, @NotBlank String name) {}

--- a/src/main/java/com/guide/domain/account/error/AccountErrorHandler.java
+++ b/src/main/java/com/guide/domain/account/error/AccountErrorHandler.java
@@ -1,0 +1,44 @@
+package com.guide.domain.account.error;
+
+import com.guide.common.error.ErrorCode;
+import com.guide.common.error.dto.BaseErrorResponse;
+import com.guide.domain.account.api.AccountController;
+import com.guide.infra.client.error.UserNotFoundException;
+import feign.FeignException;
+import feign.RetryableException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@Order(Ordered.HIGHEST_PRECEDENCE)
+@RestControllerAdvice(basePackageClasses = AccountController.class)
+public class AccountErrorHandler {
+
+    @ExceptionHandler(UserNotFoundException.class)
+    protected ResponseEntity<BaseErrorResponse> handleUserNotFoundException(
+            UserNotFoundException exception) {
+        log.warn("UserNotFoundException occurred.", exception);
+        return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                .body(BaseErrorResponse.of(ErrorCode.USER_NOT_FOUND));
+    }
+
+    @ExceptionHandler(RetryableException.class)
+    protected ResponseEntity<BaseErrorResponse> handleRetryableException(
+            RetryableException exception) {
+        log.warn("RetryableException occurred.", exception);
+        return ResponseEntity.status(HttpStatus.BAD_GATEWAY)
+                .body(BaseErrorResponse.of(ErrorCode.RETRY_MAX_ATTEMPTS));
+    }
+
+    @ExceptionHandler(FeignException.class)
+    protected ResponseEntity<BaseErrorResponse> handleFeignException(FeignException exception) {
+        log.warn("FeignException occurred.", exception);
+        return ResponseEntity.status(HttpStatus.BAD_GATEWAY)
+                .body(BaseErrorResponse.of(ErrorCode.USER_CLIENT_UNPROCESSABLE));
+    }
+}

--- a/src/main/java/com/guide/infra/client/UserClient.java
+++ b/src/main/java/com/guide/infra/client/UserClient.java
@@ -1,10 +1,17 @@
 package com.guide.infra.client;
 
 import com.guide.infra.client.config.UserClientConfiguration;
+import com.guide.infra.client.dto.UserFindApiResponse;
 import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 
 @FeignClient(
         name = "user-api",
         url = "${user.feign.base-url}",
         configuration = UserClientConfiguration.class)
-public interface UserClient {}
+public interface UserClient {
+
+    @GetMapping("/api/users/{userId}")
+    UserFindApiResponse requestUserById(@PathVariable("userId") long userId);
+}

--- a/src/main/java/com/guide/infra/client/UserClientErrorDecoder.java
+++ b/src/main/java/com/guide/infra/client/UserClientErrorDecoder.java
@@ -1,5 +1,6 @@
 package com.guide.infra.client;
 
+import com.guide.infra.client.error.UserNotFoundException;
 import feign.FeignException;
 import feign.Response;
 import feign.RetryableException;
@@ -18,6 +19,9 @@ public class UserClientErrorDecoder implements ErrorDecoder {
     public Exception decode(String methodKey, Response response) {
         int status = response.status();
         String message = response.reason();
+        if (status == HttpStatus.NOT_FOUND.value()) {
+            return new UserNotFoundException();
+        }
         if (isRetryStatus(status)) {
             return new RetryableException(
                     status, message, response.request().httpMethod(), null, response.request());

--- a/src/main/java/com/guide/infra/client/config/UserClientConfiguration.java
+++ b/src/main/java/com/guide/infra/client/config/UserClientConfiguration.java
@@ -21,10 +21,8 @@ import org.springframework.cloud.openfeign.support.SpringDecoder;
 import org.springframework.cloud.openfeign.support.SpringEncoder;
 import org.springframework.cloud.openfeign.support.SpringMvcContract;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
 import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
 
-@Configuration
 @RequiredArgsConstructor
 public class UserClientConfiguration {
 

--- a/src/main/java/com/guide/infra/client/dto/UserFindApiResponse.java
+++ b/src/main/java/com/guide/infra/client/dto/UserFindApiResponse.java
@@ -1,0 +1,16 @@
+package com.guide.infra.client.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record UserFindApiResponse(
+        @JsonProperty("data") Data data, @JsonProperty("support") Support support) {
+
+    public record Data(
+            @JsonProperty("id") long id,
+            @JsonProperty("email") String email,
+            @JsonProperty("first_name") String firstName,
+            @JsonProperty("last_name") String lastName,
+            @JsonProperty("avatar") String avatar) {}
+
+    public record Support(@JsonProperty("url") String url, @JsonProperty("text") String text) {}
+}

--- a/src/main/java/com/guide/infra/client/error/UserNotFoundException.java
+++ b/src/main/java/com/guide/infra/client/error/UserNotFoundException.java
@@ -1,0 +1,10 @@
+package com.guide.infra.client.error;
+
+import com.guide.common.error.ErrorCode;
+
+public class UserNotFoundException extends RuntimeException {
+
+    public UserNotFoundException() {
+        super(ErrorCode.USER_NOT_FOUND.getMessage());
+    }
+}

--- a/src/test/java/com/guide/domain/account/api/AccountControllerTest.java
+++ b/src/test/java/com/guide/domain/account/api/AccountControllerTest.java
@@ -20,7 +20,6 @@ import org.springframework.test.web.servlet.ResultActions;
 class AccountControllerTest extends IntegrationTest {
 
     private static final Long TEST_USER_ID = 1L;
-    private static final String TEST_EMAIL = "mike@gmail.com";
     private static final String TEST_NAME = "하나은행";
     private static final String CREATE_ACCOUNT_URL = "/api/account";
 
@@ -31,7 +30,7 @@ class AccountControllerTest extends IntegrationTest {
         public void 계좌_생성_성공() throws Exception {
             // GIVEN
             AccountCreateRequest accountCreateRequest =
-                    AccountCreateRequestSetup.build(TEST_USER_ID, TEST_EMAIL, TEST_NAME);
+                    AccountCreateRequestSetup.build(TEST_USER_ID, TEST_NAME);
 
             // WHEN
             ResultActions resultActions = requestCreateAccount(accountCreateRequest);
@@ -43,7 +42,7 @@ class AccountControllerTest extends IntegrationTest {
                     .andExpect(jsonPath("name").value(TEST_NAME))
                     .andExpect(jsonPath("balance").value(0L))
                     .andExpect(jsonPath("user.id").isNotEmpty())
-                    .andExpect(jsonPath("user.email").value(TEST_EMAIL));
+                    .andExpect(jsonPath("user.email").isNotEmpty());
         }
     }
 
@@ -62,9 +61,8 @@ class AccountControllerTest extends IntegrationTest {
 
         private static Stream<Arguments> createInvalidAccountCreateRequest() {
             return Stream.of(
-                    Arguments.arguments(AccountCreateRequestSetup.build(null, TEST_EMAIL, TEST_NAME)),
-                    Arguments.arguments(AccountCreateRequestSetup.build(TEST_USER_ID, null, TEST_NAME)),
-                    Arguments.arguments(AccountCreateRequestSetup.build(TEST_USER_ID, TEST_EMAIL, null)));
+                    Arguments.arguments(AccountCreateRequestSetup.build(null, TEST_NAME)),
+                    Arguments.arguments(AccountCreateRequestSetup.build(TEST_USER_ID, null)));
         }
     }
 

--- a/src/test/java/com/guide/domain/account/api/AccountControllerTest.java
+++ b/src/test/java/com/guide/domain/account/api/AccountControllerTest.java
@@ -5,9 +5,13 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.github.tomakehurst.wiremock.junit5.WireMockTest;
+import com.guide.common.error.ErrorCode;
 import com.guide.domain.account.dto.AccountCreateRequest;
+import com.guide.infra.client.WiremockStubFindUser;
 import com.guide.test.IntegrationTest;
 import com.guide.test.setup.request.AccountCreateRequestSetup;
+import com.guide.test.setup.response.UserClientSetup;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -24,6 +28,7 @@ class AccountControllerTest extends IntegrationTest {
     private static final String CREATE_ACCOUNT_URL = "/api/account";
 
     @Nested
+    @WireMockTest(httpPort = 8443)
     class SuccessfulTest {
 
         @Test
@@ -31,6 +36,10 @@ class AccountControllerTest extends IntegrationTest {
             // GIVEN
             AccountCreateRequest accountCreateRequest =
                     AccountCreateRequestSetup.build(TEST_USER_ID, TEST_NAME);
+            String expectedJsonResponse =
+                    objectMapper.writeValueAsString(
+                            UserClientSetup.buildUserFindApiResponse(accountCreateRequest.userId()));
+            WiremockStubFindUser.stubFindUser(accountCreateRequest.userId(), expectedJsonResponse);
 
             // WHEN
             ResultActions resultActions = requestCreateAccount(accountCreateRequest);
@@ -43,10 +52,12 @@ class AccountControllerTest extends IntegrationTest {
                     .andExpect(jsonPath("balance").value(0L))
                     .andExpect(jsonPath("user.id").isNotEmpty())
                     .andExpect(jsonPath("user.email").isNotEmpty());
+            WiremockStubFindUser.verify(1, accountCreateRequest.userId());
         }
     }
 
     @Nested
+    @WireMockTest(httpPort = 8443)
     class UnsuccessfulTests {
 
         @ParameterizedTest
@@ -63,6 +74,61 @@ class AccountControllerTest extends IntegrationTest {
             return Stream.of(
                     Arguments.arguments(AccountCreateRequestSetup.build(null, TEST_NAME)),
                     Arguments.arguments(AccountCreateRequestSetup.build(TEST_USER_ID, null)));
+        }
+
+        @Test
+        public void 계좌_생성_존재하지_않는_유저() throws Exception {
+            // GIVEN
+            AccountCreateRequest accountCreateRequest =
+                    AccountCreateRequestSetup.build(TEST_USER_ID, TEST_NAME);
+            WiremockStubFindUser.stubFindUserThrowsNotFoundException(accountCreateRequest.userId());
+
+            // WHEN
+            final ResultActions resultActions = requestCreateAccount(accountCreateRequest);
+
+            // THEN
+            resultActions
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("errorCode").value(ErrorCode.USER_NOT_FOUND.getCode()))
+                    .andExpect(jsonPath("errorMessage").value(ErrorCode.USER_NOT_FOUND.getMessage()));
+            WiremockStubFindUser.verify(1, accountCreateRequest.userId());
+        }
+
+        @Test
+        public void 계좌_생성_유저_API_커넥션_타임아웃() throws Exception {
+            // GIVEN
+            AccountCreateRequest accountCreateRequest =
+                    AccountCreateRequestSetup.build(TEST_USER_ID, TEST_NAME);
+            WiremockStubFindUser.stubFindUserThrowsConnectionTimeout(accountCreateRequest.userId());
+
+            // WHEN
+            final ResultActions resultActions = requestCreateAccount(accountCreateRequest);
+
+            // THEN
+            resultActions
+                    .andExpect(status().isBadGateway())
+                    .andExpect(jsonPath("errorCode").value(ErrorCode.RETRY_MAX_ATTEMPTS.getCode()))
+                    .andExpect(jsonPath("errorMessage").value(ErrorCode.RETRY_MAX_ATTEMPTS.getMessage()));
+            WiremockStubFindUser.verify(3, accountCreateRequest.userId());
+        }
+
+        @Test
+        public void 계좌_생성_유저_API_서버에러() throws Exception {
+            // GIVEN
+            AccountCreateRequest accountCreateRequest =
+                    AccountCreateRequestSetup.build(TEST_USER_ID, TEST_NAME);
+            WiremockStubFindUser.stubFindUserThrowsServerUnavailable(accountCreateRequest.userId());
+
+            // WHEN
+            final ResultActions resultActions = requestCreateAccount(accountCreateRequest);
+
+            // THEN
+            resultActions
+                    .andExpect(status().isBadGateway())
+                    .andExpect(jsonPath("errorCode").value(ErrorCode.USER_CLIENT_UNPROCESSABLE.getCode()))
+                    .andExpect(
+                            jsonPath("errorMessage").value(ErrorCode.USER_CLIENT_UNPROCESSABLE.getMessage()));
+            WiremockStubFindUser.verify(1, accountCreateRequest.userId());
         }
     }
 

--- a/src/test/java/com/guide/domain/account/application/AccountCreateServiceTest.java
+++ b/src/test/java/com/guide/domain/account/application/AccountCreateServiceTest.java
@@ -34,8 +34,7 @@ class AccountCreateServiceTest extends MockTest {
         void 계좌_생성_성공() {
             // GIVEN
             AccountCreateRequest accountCreateRequest =
-                    AccountCreateRequestSetup.build(
-                            account.getUser().getId(), account.getUser().getEmail(), account.getName());
+                    AccountCreateRequestSetup.build(account.getUser().getId(), account.getName());
             given(accountRepository.save(any(Account.class))).willReturn(account);
 
             // WHEN
@@ -43,7 +42,7 @@ class AccountCreateServiceTest extends MockTest {
 
             // THEN
             assertEquals(account.getUser().getId(), accountCreateRequest.userId());
-            assertEquals(account.getUser().getEmail(), accountCreateRequest.email());
+            assertNotNull(account.getUser().getEmail());
             assertEquals(account.getBalance(), 0);
             assertEquals(account.getName(), accountCreateRequest.name());
         }

--- a/src/test/java/com/guide/domain/account/application/AccountCreateServiceTest.java
+++ b/src/test/java/com/guide/domain/account/application/AccountCreateServiceTest.java
@@ -7,9 +7,12 @@ import static org.mockito.BDDMockito.given;
 import com.guide.domain.account.dao.AccountRepository;
 import com.guide.domain.account.dto.AccountCreateRequest;
 import com.guide.domain.account.entity.Account;
+import com.guide.infra.client.UserClient;
+import com.guide.infra.client.error.UserNotFoundException;
 import com.guide.test.MockTest;
 import com.guide.test.setup.entity.AccountSetup;
 import com.guide.test.setup.request.AccountCreateRequestSetup;
+import com.guide.test.setup.response.UserClientSetup;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -19,6 +22,7 @@ import org.mockito.Mock;
 class AccountCreateServiceTest extends MockTest {
 
     @Mock private AccountRepository accountRepository;
+    @Mock private UserClient userClient;
     @InjectMocks private AccountCreateService accountCreateService;
     private Account account;
 
@@ -33,9 +37,12 @@ class AccountCreateServiceTest extends MockTest {
         @Test
         void 계좌_생성_성공() {
             // GIVEN
+            Long userId = account.getUser().getId();
             AccountCreateRequest accountCreateRequest =
-                    AccountCreateRequestSetup.build(account.getUser().getId(), account.getName());
+                    AccountCreateRequestSetup.build(userId, account.getName());
             given(accountRepository.save(any(Account.class))).willReturn(account);
+            given(userClient.requestUserById(userId))
+                    .willReturn(UserClientSetup.buildUserFindApiResponse(userId));
 
             // WHEN
             Account account = accountCreateService.create(accountCreateRequest);
@@ -49,5 +56,20 @@ class AccountCreateServiceTest extends MockTest {
     }
 
     @Nested
-    class UnsuccessfulTests {}
+    class UnsuccessfulTests {
+
+        @Test
+        void 계좌_생성_생성_실패_없는_회원() {
+            // GIVEN
+            Long userId = account.getUser().getId();
+            AccountCreateRequest accountCreateRequest =
+                    AccountCreateRequestSetup.build(userId, account.getName());
+            given(userClient.requestUserById(userId)).willThrow(new UserNotFoundException());
+
+            // WHEN
+            // THEN
+            assertThrows(
+                    UserNotFoundException.class, () -> accountCreateService.create(accountCreateRequest));
+        }
+    }
 }

--- a/src/test/java/com/guide/infra/client/WiremockStubFindUser.java
+++ b/src/test/java/com/guide/infra/client/WiremockStubFindUser.java
@@ -1,0 +1,46 @@
+package com.guide.infra.client;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.exactly;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.notFound;
+import static com.github.tomakehurst.wiremock.client.WireMock.serviceUnavailable;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.google.common.net.HttpHeaders;
+import org.springframework.http.MediaType;
+
+public class WiremockStubFindUser {
+
+    private static final String FIND_USER_URL = "/api/users/%s";
+
+    public static void stubFindUser(long userId, String expectedJsonResponse) {
+        stubFor(
+                get(String.format(FIND_USER_URL, userId))
+                        .willReturn(
+                                aResponse()
+                                        .withStatus(200)
+                                        .withHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                                        .withBody(expectedJsonResponse)));
+    }
+
+    public static void stubFindUserThrowsConnectionTimeout(long userId) {
+        stubFor(get(String.format(FIND_USER_URL, userId)).willReturn(aResponse().withFixedDelay(600)));
+    }
+
+    public static void stubFindUserThrowsNotFoundException(long userId) {
+        stubFor(get(String.format(FIND_USER_URL, userId)).willReturn(notFound()));
+    }
+
+    public static void stubFindUserThrowsServerUnavailable(long userId) {
+        stubFor(get(String.format(FIND_USER_URL, userId)).willReturn(serviceUnavailable()));
+    }
+
+    public static void verify(int expected, long userId) {
+        WireMock.verify(
+                exactly(expected), getRequestedFor(urlEqualTo(String.format(FIND_USER_URL, userId))));
+    }
+}

--- a/src/test/java/com/guide/test/setup/request/AccountCreateRequestSetup.java
+++ b/src/test/java/com/guide/test/setup/request/AccountCreateRequestSetup.java
@@ -5,14 +5,13 @@ import com.guide.domain.account.dto.AccountCreateRequest;
 public class AccountCreateRequestSetup {
 
     private static final Long TEST_USER_ID = 1L;
-    private static final String TEST_EMAIL = "mike@gmail.com";
     private static final String TEST_NAME = "하나은행";
 
     public static AccountCreateRequest build() {
-        return build(TEST_USER_ID, TEST_EMAIL, TEST_NAME);
+        return build(TEST_USER_ID, TEST_NAME);
     }
 
-    public static AccountCreateRequest build(Long userId, String email, String name) {
-        return new AccountCreateRequest(userId, email, name);
+    public static AccountCreateRequest build(Long userId, String name) {
+        return new AccountCreateRequest(userId, name);
     }
 }

--- a/src/test/java/com/guide/test/setup/response/UserClientSetup.java
+++ b/src/test/java/com/guide/test/setup/response/UserClientSetup.java
@@ -1,0 +1,27 @@
+package com.guide.test.setup.response;
+
+import com.guide.infra.client.dto.UserFindApiResponse;
+import com.guide.infra.client.dto.UserFindApiResponse.Data;
+import com.guide.infra.client.dto.UserFindApiResponse.Support;
+
+public class UserClientSetup {
+
+    private static final String EMAIL = "george.bluth@reqres.in";
+    private static final String FIRST_NAME = "George";
+    private static final String LAST_NAME = "Bluth";
+    private static final String AVATAR = "https://reqres.in/img/faces/1-image.jpg";
+
+    public static UserFindApiResponse buildUserFindApiResponse(long id) {
+        return buildUserFindApiResponse(id, EMAIL, FIRST_NAME, LAST_NAME, AVATAR);
+    }
+
+    private static UserFindApiResponse buildUserFindApiResponse(
+            long id, String email, String firstName, String lastName, String avatar) {
+        Data data = new Data(id, email, firstName, lastName, avatar);
+        Support support =
+                new Support(
+                        "https://reqres.in/#support-heading",
+                        "To keep ReqRes free, contributions towards server costs are appreciated!");
+        return new UserFindApiResponse(data, support);
+    }
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,0 +1,22 @@
+spring:
+  mvc:
+    throw-exception-if-no-handler-found: true
+  web:
+    resources:
+      add-mappings: false
+  jpa:
+    open-in-view: false
+    show-sql: true
+    hibernate:
+      ddl-auto: create-drop
+    database: h2
+
+user:
+  feign:
+    base-url: localhost:8443
+    connection-timeout-millis: 200
+    read-timeout-millis: 500
+    retry:
+      period-millis: 1000
+      max-period-millis: 200
+      attempts: 3


### PR DESCRIPTION
## Description
- 계좌 생성 API에 유저 정보를 조회하는 HTTP API를 추가합니다.
- Wiremock 라이브러리를 추가한 테스트 케이스를 작성합니다.
- test를 위한 application property 파일을 추가합니다.
## AS-IS
- 유저 정보에 대한 검증 없음
## TO-BE
- HTTP 통신을 통한 유저 정보 존재 여부 검증